### PR TITLE
Added DMI_Level_Data_T packet in DMI_Messages_bothways_Pkg

### DIFF
--- a/model/Scade/System/APITypes/DMI_Messages_Bothways_Pkg.xscade
+++ b/model/Scade/System/APITypes/DMI_Messages_Bothways_Pkg.xscade
@@ -348,12 +348,67 @@
 						<ed:Type oid="!ed/27e32/5982/10B4/54d4b12f14d7"/>
 					</pragmas>
 				</Type>
+				<Type name="DMI_Level_Data_T">
+					<definition>
+						<Struct>
+							<fields>
+								<Field name="valid">
+									<type>
+										<NamedType>
+											<type>
+												<TypeRef name="bool"/>
+											</type>
+										</NamedType>
+									</type>
+									<pragmas>
+										<ed:Field oid="!ed/a495/411C/186C/5540f02544d8" xmlns="http://www.esterel-technologies.com/ns/scade/pragmas/editor/4">
+											<comment>Valid indicator for the packet</comment>
+										</ed:Field>
+									</pragmas>
+								</Field>
+								<Field name="systemTime">
+									<type>
+										<NamedType>
+											<type>
+												<TypeRef name="Obu_BasicTypes_Pkg::T_internal_Type"/>
+											</type>
+										</NamedType>
+									</type>
+									<pragmas>
+										<ed:Field oid="!ed/a496/411C/186C/5540f0255a62" xmlns="http://www.esterel-technologies.com/ns/scade/pragmas/editor/4">
+											<comment>Clock value of the last received dynamic data.</comment>
+										</ed:Field>
+									</pragmas>
+								</Field>
+								<Field name="level">
+									<type>
+										<NamedType>
+											<type>
+												<TypeRef name="DMI_Types_Pkg::DMI_level_T"/>
+											</type>
+										</NamedType>
+									</type>
+									<pragmas>
+										<ed:Field oid="!ed/a497/411C/186C/5540f0256162" xmlns="http://www.esterel-technologies.com/ns/scade/pragmas/editor/4">
+											<comment>The ETCS level selected by the Driver</comment>
+										</ed:Field>
+									</pragmas>
+								</Field>
+							</fields>
+						</Struct>
+					</definition>
+					<pragmas>
+						<ed:Type oid="!ed/a494/411C/186C/5540f02540c4" xmlns="http://www.esterel-technologies.com/ns/scade/pragmas/editor/4">
+							<comment>DMI &lt;-&gt; EVC: supplies the DMI with default ETCS level. Reversely, supplies the EVC with the data related to ETCS level selected by the driver</comment>
+						</ed:Type>
+					</pragmas>
+				</Type>
 			</declarations>
 			<pragmas>
 				<ed:Package oid="!ed/13bd5/35F0/7C4/54c65aa37bf5" xmlns="http://www.esterel-technologies.com/ns/scade/pragmas/editor/4">
 					<diagrams>
 						<TreeDiagram landscape="false" format="A4 (210 297)" oid="!ed/13bd6/35F0/7C4/54c65aa3541b" blockKind="constants"/>
-						<TreeDiagram landscape="false" format="A4 (210 297)" oid="!ed/13bd7/35F0/7C4/54c65aa35ebb" blockKind="types" columnsSize="0, 212, 150, 300"/>
+						<TreeDiagram landscape="false" format="A4 (210 297)" oid="!ed/13bd7/35F0/7C4/54c65aa35ebb" blockKind="types" columnsSize="0, 212, 236, 300"/>
 						<TreeDiagram landscape="false" format="A4 (210 297)" oid="!ed/13bd8/35F0/7C4/54c65aa36010" blockKind="sensors"/>
 					</diagrams>
 				</ed:Package>


### PR DESCRIPTION
This packet was missing. It's necessary to communicate the selected ETCS level to the DMI_Manager.